### PR TITLE
PS-915 - Upgrade GHA Workflow steps to run on pinned Ubuntu 22.04

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   pr-pull:
     if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-22.04, macOS-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
This PR is to pin the workflow step versions to `22.04`, with the intent to identify any issues and fix those repos, and to move forward on a manual upgrade basis when the time and pipelines are ready.

## Context
GHA Workflows were set to run on `ubuntu-latest`, which worked fine until some of them failed when GitHub started upgrading the runners to resolve `latest` to `22.04` instead of the previous LTS, `20.04`.

See [PS-915](https://offerzen.atlassian.net/browse/PS-915?atlOrigin=eyJpIjoiMDEzM2E3YTJiOWY3NGYwYmFhMTY3YThiOWE0Nzc0NmIiLCJwIjoiaiJ9) for more info.

[PS-915]: https://offerzen.atlassian.net/browse/PS-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ